### PR TITLE
DAC6-3328: Refactor validation for FI details API

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementController.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementController.scala
@@ -23,7 +23,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import uk.gov.hmrc.crsfatcafimanagement.auth.AuthActionSets
 import uk.gov.hmrc.crsfatcafimanagement.config.AppConfig
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
-import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.CreateFIDetailsRequest
+import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.RequestDetails
 import uk.gov.hmrc.crsfatcafimanagement.models.error.ErrorDetails
 import uk.gov.hmrc.crsfatcafimanagement.models.errors.CreateSubmissionError
 import uk.gov.hmrc.crsfatcafimanagement.services.CADXSubmissionService
@@ -46,7 +46,7 @@ class FIManagementController @Inject() (
   def createsFinancialInstitutions(): Action[JsValue] = authenticator.authenticateAll.async(parse.json) {
     implicit request =>
       request.body
-        .validate[CreateFIDetailsRequest]
+        .validate[RequestDetails]
         .fold(
           invalid =>
             Future.successful {

--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/CADXRequestModels/RequestDetails.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/CADXRequestModels/RequestDetails.scala
@@ -20,15 +20,14 @@ import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.crsfatcafimanagement.models.{AddressDetails, ContactDetails, TINDetails}
 
 final case class RequestDetails(
-  FIID: String,
   FIName: String,
   SubscriptionID: String,
   TINDetails: List[TINDetails],
   IsFIUser: Boolean,
   IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
-  PrimaryContactDetails: ContactDetails,
-  SecondaryContactDetails: ContactDetails
+  PrimaryContactDetails: Option[ContactDetails],
+  SecondaryContactDetails: Option[ContactDetails]
 )
 
 object RequestDetails {

--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/ContactDetails.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/ContactDetails.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.crsfatcafimanagement.models
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class ContactDetails(ContactName: String, EmailAddress: String, PhoneNumber: String)
+final case class ContactDetails(ContactName: String, EmailAddress: String, PhoneNumber: Option[String])
 
 object ContactDetails {
   implicit val format: OFormat[ContactDetails] = Json.format[ContactDetails]

--- a/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.crsfatcafimanagement.services
 import play.api.Logging
 import play.api.http.Status.OK
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
-import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.CreateFIDetailsRequest
+import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.{CreateFIDetails, CreateFIDetailsRequest, RequestCommon, RequestDetails}
+import uk.gov.hmrc.crsfatcafimanagement.models.RequestType.CREATE
 import uk.gov.hmrc.crsfatcafimanagement.models.errors.CreateSubmissionError
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -29,9 +30,21 @@ import scala.concurrent.{ExecutionContext, Future}
 class CADXSubmissionService @Inject() (connector: CADXConnector) extends Logging {
 
   def createFI(
-    createFIDetails: CreateFIDetailsRequest
-  )(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[Either[CreateSubmissionError, Unit]] =
-    connector.createFI(createFIDetails).map {
+    requestDetails: RequestDetails
+  )(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[Either[CreateSubmissionError, Unit]] = {
+    val req = CreateFIDetailsRequest(
+      FIManagementType = CreateFIDetails(
+        RequestCommon = RequestCommon(
+          OriginatingSystem = "crs-fatca-fi-management",
+          TransmittingSystem = "crs-fatca-fi-management",
+          RequestType = CREATE,
+          Regime = "CRSFATCA",
+          RequestParameters = List.empty
+        ),
+        RequestDetails = requestDetails
+      )
+    )
+    connector.createFI(req).map {
       res =>
         res.status match {
           case OK => Right(())
@@ -40,5 +53,6 @@ class CADXSubmissionService @Inject() (connector: CADXConnector) extends Logging
             Left(CreateSubmissionError(status))
         }
     }
+  }
 
 }

--- a/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
+++ b/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
@@ -51,7 +51,7 @@ trait ModelGenerators {
         contactName  <- stringOfLength(105)
         emailAddress <- validPhoneNumber
         phoneNumber  <- stringOfLength(24)
-      } yield ContactDetails(contactName, emailAddress, phoneNumber)
+      } yield ContactDetails(contactName, emailAddress, Some(phoneNumber))
     }
 
   implicit val arbitraryTINDetails: Arbitrary[TINDetails] =
@@ -165,7 +165,6 @@ trait ModelGenerators {
 
   implicit val arbitraryRequestDetails: Arbitrary[RequestDetails] = Arbitrary {
     for {
-      fiId                    <- stringOfLength(15)
       fiName                  <- stringOfLength(105)
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
@@ -175,15 +174,14 @@ trait ModelGenerators {
       primaryContactDetails   <- arbitrary[ContactDetails]
       secondaryContactDetails <- arbitrary[ContactDetails]
     } yield RequestDetails(
-      FIID = fiId,
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = List(tinDetails),
       IsFIUser = isFIUser,
       IsFATCAReporting = isFATCAReporting,
       AddressDetails = addressDetails,
-      PrimaryContactDetails = primaryContactDetails,
-      SecondaryContactDetails = secondaryContactDetails
+      PrimaryContactDetails = Some(primaryContactDetails),
+      SecondaryContactDetails = Some(secondaryContactDetails)
     )
   }
 

--- a/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.crsfatcafimanagement.SpecBase
 import uk.gov.hmrc.crsfatcafimanagement.auth.{AllowAllAuthAction, FakeAllowAllAuthAction}
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
 import uk.gov.hmrc.crsfatcafimanagement.generators.Generators
-import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.CreateFIDetailsRequest
+import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.{CreateFIDetailsRequest, RequestDetails}
 import uk.gov.hmrc.crsfatcafimanagement.models.error.ErrorDetails
 import uk.gov.hmrc.crsfatcafimanagement.models.errors.CreateSubmissionError
 import uk.gov.hmrc.crsfatcafimanagement.models.{FIDetail, ViewFIDetailsResponse}
@@ -66,55 +66,35 @@ class FIManagementControllerSpec extends SpecBase with Generators {
   val fiDetailsRequestJson: JsValue = Json.parse(
     """
       |{
-      |  "FIManagementType": {
-      |    "RequestCommon": {
-      |      "TransmittingSystem": "192.168.1.1",
-      |      "OriginatingSystem": "192.168.1.2",
-      |      "RequestType": "CREATE",
-      |      "Regime": "CRSFATCA",
-      |      "RequestParameters": [
-      |        {
-      |          "ParamName": "ExampleParam1",
-      |          "ParamValue": "Value1"
-      |        },
-      |        {
-      |          "ParamName": "ExampleParam2",
-      |          "ParamValue": "Value2"
-      |        }
-      |      ]
-      |    },
-      |    "RequestDetails": {
-      |      "SubscriptionID": "123456789012345",
-      |      "FIID": "FI1234567890123",
-      |      "FIName": "Financial Institution",
-      |      "TINDetails": [
-      |        {
-      |          "TIN": "TIN123456789",
-      |          "TINType": "GIIN",
-      |          "IssuedBy": "US"
-      |        }
-      |      ],
-      |      "IsFIUser": false,
-      |      "IsFATCAReporting": true,
-      |      "PrimaryContactDetails": {
-      |        "PhoneNumber": "07123456789",
-      |        "ContactName": "John Doe",
-      |        "EmailAddress": "john.doe@example.com"
-      |      },
-      |      "SecondaryContactDetails": {
-      |        "PhoneNumber": "07876543210",
-      |        "ContactName": "Jane Doe",
-      |        "EmailAddress": "jane.doe@example.com"
-      |      },
-      |      "AddressDetails": {
-      |        "AddressLine1": "100 Sutton Street",
-      |        "AddressLine2": "Wokingham",
-      |        "AddressLine3": "Surrey",
-      |        "AddressLine4": "London",
-      |        "PostalCode": "DH14EJ",
-      |        "CountryCode": "GB"
-      |      }
+      |  "SubscriptionID": "123456789012345",
+      |  "FIID": "FI1234567890123",
+      |  "FIName": "Financial Institution",
+      |  "TINDetails": [
+      |    {
+      |      "TIN": "TIN123456789",
+      |      "TINType": "GIIN",
+      |      "IssuedBy": "US"
       |    }
+      |  ],
+      |  "IsFIUser": false,
+      |  "IsFATCAReporting": true,
+      |  "PrimaryContactDetails": {
+      |    "PhoneNumber": "07123456789",
+      |    "ContactName": "John Doe",
+      |    "EmailAddress": "john.doe@example.com"
+      |  },
+      |  "SecondaryContactDetails": {
+      |    "PhoneNumber": "07876543210",
+      |    "ContactName": "Jane Doe",
+      |    "EmailAddress": "jane.doe@example.com"
+      |  },
+      |  "AddressDetails": {
+      |    "AddressLine1": "100 Sutton Street",
+      |    "AddressLine2": "Wokingham",
+      |    "AddressLine3": "Surrey",
+      |    "AddressLine4": "London",
+      |    "PostalCode": "DH14EJ",
+      |    "CountryCode": "GB"
       |  }
       |}""".stripMargin
   )
@@ -122,26 +102,6 @@ class FIManagementControllerSpec extends SpecBase with Generators {
   val invalidFiDetailsRequestJson: JsValue = Json.parse(
     """
       |{
-      |  "FIManagementType": {
-      |    "RequestCommon": {
-      |      "TransmittingSystem": "192.168.1.1",
-      |      "OriginatingSystem": "192.168.1.2",
-      |      "RequestType": "CREATE",
-      |      "Regime": "CRSFATCA",
-      |      "RequestParameters": [
-      |        {
-      |          "ParamName": "ExampleParam1",
-      |          "ParamValue": "Value1"
-      |        },
-      |        {
-      |          "ParamName": "ExampleParam2",
-      |          "ParamValue": "Value2"
-      |        }
-      |      ]
-      |    },
-      |    "RequestDetails": {
-      |    }
-      |  }
       |}""".stripMargin
   )
 
@@ -267,7 +227,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       "must return OK when UpdateSubscription was successful" in {
         when(
           mockCADXSubmissionService
-            .createFI(any[CreateFIDetailsRequest]())(
+            .createFI(any[RequestDetails]())(
               any[HeaderCarrier](),
               any[ExecutionContext]()
             )
@@ -291,7 +251,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       "must return 500 with a json validation error when receiving invalid json" in {
         when(
           mockCADXSubmissionService
-            .createFI(any[CreateFIDetailsRequest]())(
+            .createFI(any[RequestDetails]())(
               any[HeaderCarrier](),
               any[ExecutionContext]()
             )
@@ -315,7 +275,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       "must return a create submission error when not able to create FI" in {
         when(
           mockCADXSubmissionService
-            .createFI(any[CreateFIDetailsRequest]())(
+            .createFI(any[RequestDetails]())(
               any[HeaderCarrier](),
               any[ExecutionContext]()
             )


### PR DESCRIPTION
This commit refactors the validation logic for financial institution details by updating the expected input model to `RequestDetails` instead of `CreateFIDetailsRequest`. It also modifies the `ContactDetails` model to make the phone number optional and updates relevant tests to align with these changes.