### PR TITLE
DAC6-3328: Make AddressLine2 optional in AddressDetails

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/AddressDetails.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/AddressDetails.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 final case class AddressDetails(
   AddressLine1: String,
-  AddressLine2: String,
+  AddressLine2: Option[String],
   AddressLine3: String,
   AddressLine4: Option[String],
   CountryCode: Option[String],

--- a/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
+++ b/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
@@ -30,7 +30,7 @@ trait ModelGenerators {
   implicit val arbitraryAddressDetails: Arbitrary[AddressDetails] = Arbitrary {
     for {
       addressLine1 <- stringOfLength(35)
-      addressLine2 <- stringOfLength(35)
+      addressLine2 <- Gen.option(stringOfLength(35))
       addressLine3 <- stringOfLength(35)
       addressLine4 <- Gen.option(stringOfLength(35))
       postalCode   <- Gen.option(stringOfLength(10))


### PR DESCRIPTION
Updated the AddressLine2 field in the AddressDetails model to be an Option[String]. Adjusted the corresponding generator to accommodate this change.