### PR TITLE
DAC6-3328:: Disable JUnitXmlReportPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ ThisBuild / scalaVersion := "2.13.12"
 
 lazy val microservice = Project("crs-fatca-fi-management", file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     PlayKeys.playDefaultPort := 10034,


### PR DESCRIPTION
Disable JUnitXmlReportPlugin in the project configuration to prevent issues related to https://github.com/scalatest/scalatest/issues/1427. This change ensures smoother build and testing processes.