### PR TITLE
DAC6-3186: Add update functionality

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementController.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementController.scala
@@ -24,6 +24,8 @@ import uk.gov.hmrc.crsfatcafimanagement.auth.AuthActionSets
 import uk.gov.hmrc.crsfatcafimanagement.config.AppConfig
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
 import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.{CreateRequestDetails, RemoveRequestDetails}
+import uk.gov.hmrc.crsfatcafimanagement.models.RequestType
+import uk.gov.hmrc.crsfatcafimanagement.models.RequestType.{CREATE, UPDATE}
 import uk.gov.hmrc.crsfatcafimanagement.models.error.ErrorDetails
 import uk.gov.hmrc.crsfatcafimanagement.models.errors.CreateSubmissionError
 import uk.gov.hmrc.crsfatcafimanagement.services.CADXSubmissionService
@@ -43,7 +45,11 @@ class FIManagementController @Inject() (
     extends BackendController(controllerComponents)
     with Logging {
 
-  def createsFinancialInstitutions(): Action[JsValue] = authenticator.authenticateAll.async(parse.json) {
+  def createFinancialInstitution(): Action[JsValue] = submitFinancialInstitutions(CREATE)
+
+  def updateFinancialInstitution(): Action[JsValue] = submitFinancialInstitutions(UPDATE)
+
+  private def submitFinancialInstitutions(requestType: RequestType): Action[JsValue] = authenticator.authenticateAll.async(parse.json) {
     implicit request =>
       request.body
         .validate[CreateRequestDetails]
@@ -54,7 +60,7 @@ class FIManagementController @Inject() (
               InternalServerError("Json Validation Failed")
             },
           validReq =>
-            service.createFI(validReq).map {
+            service.createFI(validReq, requestType).map {
               case Right(_) => Ok
               case Left(CreateSubmissionError(value)) =>
                 logger.warn(s"CreateSubmissionError $value")

--- a/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
@@ -20,7 +20,8 @@ import play.api.Logging
 import play.api.http.Status.OK
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
 import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels._
-import uk.gov.hmrc.crsfatcafimanagement.models.RequestType.{CREATE, DELETE}
+import uk.gov.hmrc.crsfatcafimanagement.models.RequestType
+import uk.gov.hmrc.crsfatcafimanagement.models.RequestType.DELETE
 import uk.gov.hmrc.crsfatcafimanagement.models.errors.CreateSubmissionError
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -30,12 +31,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class CADXSubmissionService @Inject() (connector: CADXConnector) extends Logging {
 
   def createFI(
-    requestDetails: CreateRequestDetails
+    requestDetails: CreateRequestDetails,
+    requestType: RequestType = RequestType.CREATE
   )(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[Either[CreateSubmissionError, Unit]] = {
     val reqCommon = RequestCommon(
       OriginatingSystem = "crs-fatca-fi-management",
       TransmittingSystem = "crs-fatca-fi-management",
-      RequestType = CREATE,
+      RequestType = requestType,
       Regime = "CRSFATCA",
       RequestParameters = List.empty
     )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,8 +1,9 @@
 # microservice specific routes
 
-POST       /financial-institutions/create                                           uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.createsFinancialInstitutions
-POST       /financial-institutions/remove                                           uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.removeFinancialInstitution
+POST        /financial-institutions/create                                         uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.createFinancialInstitution()
+PUT         /financial-institutions/update                                         uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.updateFinancialInstitution()
+POST        /financial-institutions/remove                                         uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.removeFinancialInstitution
 
-GET        /financial-institutions/:subscriptionId                                  uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.listFinancialInstitutions(subscriptionId: String)
+GET         /financial-institutions/:subscriptionId                                uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.listFinancialInstitutions(subscriptionId: String)
 
-GET        /financial-institutions/:subscriptionId/:financialInstitutionId          uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.viewFinancialInstitution(subscriptionId: String, financialInstitutionId: String)
+GET         /financial-institutions/:subscriptionId/:financialInstitutionId        uk.gov.hmrc.crsfatcafimanagement.controllers.FIManagementController.viewFinancialInstitution(subscriptionId: String, financialInstitutionId: String)

--- a/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.crsfatcafimanagement.auth.{AllowAllAuthAction, FakeAllowAllAu
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
 import uk.gov.hmrc.crsfatcafimanagement.generators.Generators
 import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels.{CreateRequestDetails, RemoveRequestDetails}
+import uk.gov.hmrc.crsfatcafimanagement.models.RequestType.{CREATE, UPDATE}
 import uk.gov.hmrc.crsfatcafimanagement.models.error.ErrorDetails
 import uk.gov.hmrc.crsfatcafimanagement.models.errors.CreateSubmissionError
 import uk.gov.hmrc.crsfatcafimanagement.models.{FIDetail, ViewFIDetailsResponse}
@@ -227,7 +228,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       "must return OK when UpdateSubscription was successful" in {
         when(
           mockCADXSubmissionService
-            .createFI(any[CreateRequestDetails]())(
+            .createFI(any[CreateRequestDetails](), mockitoEq(CREATE))(
               any[HeaderCarrier](),
               any[ExecutionContext]()
             )
@@ -240,7 +241,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
         val request =
           FakeRequest(
             POST,
-            routes.FIManagementController.createsFinancialInstitutions.url
+            routes.FIManagementController.createFinancialInstitution().url
           ).withJsonBody(fiDetailsRequestJson)
 
         val result = route(app, request).value
@@ -251,7 +252,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       "must return 500 with a json validation error when receiving invalid json" in {
         when(
           mockCADXSubmissionService
-            .createFI(any[CreateRequestDetails]())(
+            .createFI(any[CreateRequestDetails](), mockitoEq(CREATE))(
               any[HeaderCarrier](),
               any[ExecutionContext]()
             )
@@ -264,7 +265,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
         val request =
           FakeRequest(
             POST,
-            routes.FIManagementController.createsFinancialInstitutions.url
+            routes.FIManagementController.createFinancialInstitution().url
           ).withJsonBody(invalidFiDetailsRequestJson)
 
         val result = route(app, request).value
@@ -275,7 +276,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       "must return a create submission error when not able to create FI" in {
         when(
           mockCADXSubmissionService
-            .createFI(any[CreateRequestDetails]())(
+            .createFI(any[CreateRequestDetails](), mockitoEq(CREATE))(
               any[HeaderCarrier](),
               any[ExecutionContext]()
             )
@@ -288,7 +289,81 @@ class FIManagementControllerSpec extends SpecBase with Generators {
         val request =
           FakeRequest(
             POST,
-            routes.FIManagementController.createsFinancialInstitutions.url
+            routes.FIManagementController.createFinancialInstitution().url
+          ).withJsonBody(fiDetailsRequestJson)
+
+        val result = route(app, request).value
+        status(result) mustEqual INTERNAL_SERVER_ERROR
+
+      }
+    }
+
+    "updateFinancialInstitution" - {
+      "must return OK when UpdateSubscription was successful" in {
+        when(
+          mockCADXSubmissionService
+            .createFI(any[CreateRequestDetails](), mockitoEq(UPDATE))(
+              any[HeaderCarrier](),
+              any[ExecutionContext]()
+            )
+        ).thenReturn(
+          Future.successful(
+            Right(())
+          )
+        )
+
+        val request =
+          FakeRequest(
+            PUT,
+            routes.FIManagementController.updateFinancialInstitution().url
+          ).withJsonBody(fiDetailsRequestJson)
+
+        val result = route(app, request).value
+        status(result) mustEqual OK
+
+      }
+
+      "must return 500 with a json validation error when receiving invalid json" in {
+        when(
+          mockCADXSubmissionService
+            .createFI(any[CreateRequestDetails](), mockitoEq(UPDATE))(
+              any[HeaderCarrier](),
+              any[ExecutionContext]()
+            )
+        ).thenReturn(
+          Future.successful(
+            Right(())
+          )
+        )
+
+        val request =
+          FakeRequest(
+            PUT,
+            routes.FIManagementController.updateFinancialInstitution().url
+          ).withJsonBody(invalidFiDetailsRequestJson)
+
+        val result = route(app, request).value
+        status(result) mustEqual INTERNAL_SERVER_ERROR
+
+      }
+
+      "must return a create submission error when not able to create FI" in {
+        when(
+          mockCADXSubmissionService
+            .createFI(any[CreateRequestDetails](), mockitoEq(UPDATE))(
+              any[HeaderCarrier](),
+              any[ExecutionContext]()
+            )
+        ).thenReturn(
+          Future.successful(
+            Left(CreateSubmissionError(401))
+          )
+        )
+
+        val request =
+          FakeRequest(
+            PUT,
+            routes.FIManagementController.updateFinancialInstitution().url
           ).withJsonBody(fiDetailsRequestJson)
 
         val result = route(app, request).value


### PR DESCRIPTION
Implemented the updateFinancialInstitution endpoint and corresponding service logic. Refactored existing createFI method to accommodate request type parameter and updated tests accordingly.