### PR TITLE
DAC6-3549: Update API context paths

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -87,7 +87,7 @@ microservice {
       host = localhost
       port = 10035
       protocol = http
-      context = "/ASMService/v1/FIManagement"
+      context = "/dac6/dct139a/v1"
       bearer-token = ""
       environment = ""
     }
@@ -96,7 +96,7 @@ microservice {
       host = localhost
       port = 10035
       protocol = http
-      context = "/ASMService/v1/VIEW"
+      context = "/dac6/dct139b/v1"
       bearer-token = ""
       environment = ""
     }

--- a/it/test/uk/gov/hmrc/crsfatcafimanagement/connectors/CADXConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/crsfatcafimanagement/connectors/CADXConnectorSpec.scala
@@ -69,7 +69,7 @@ class CADXConnectorSpec extends SpecBase with Generators with IntegrationPatienc
             val stubbedResponse = response.modify(_.ViewFIDetails.ResponseDetails.FIDetails).setTo(List(fiDetail))
 
             stubResponse(
-              url = s"/ASMService/v1/VIEW/$subscriptionId",
+              url = s"/dac6/dct139b/v1/$subscriptionId",
               statusCode = OK,
               requestMethod = RequestMethod.GET,
               requestHeaders = Map.empty,
@@ -91,7 +91,7 @@ class CADXConnectorSpec extends SpecBase with Generators with IntegrationPatienc
                 val subscriptionId = fiDetail.SubscriptionID
 
                 stubResponse(
-                  url = s"/ASMService/v1/VIEW/$subscriptionId",
+                  url = s"/dac6/dct139b/v1/$subscriptionId",
                   statusCode = errorStatusCode,
                   requestMethod = RequestMethod.GET,
                   requestHeaders = Map.empty
@@ -114,7 +114,7 @@ class CADXConnectorSpec extends SpecBase with Generators with IntegrationPatienc
             val stubbedResponse = response.modify(_.ViewFIDetails.ResponseDetails.FIDetails).setTo(List(fiDetail))
 
             stubResponse(
-              url = s"/ASMService/v1/VIEW/$subscriptionId/$fiId",
+              url = s"/dac6/dct139b/v1/$subscriptionId/$fiId",
               statusCode = OK,
               requestMethod = RequestMethod.GET,
               requestHeaders = Map.empty,
@@ -137,7 +137,7 @@ class CADXConnectorSpec extends SpecBase with Generators with IntegrationPatienc
                 val fiId           = fiDetail.FIID
 
                 stubResponse(
-                  url = s"/ASMService/v1/VIEW/$subscriptionId/$fiId",
+                  url = s"/dac6/dct139b/v1/$subscriptionId/$fiId",
                   statusCode = errorStatusCode,
                   requestMethod = RequestMethod.GET,
                   requestHeaders = Map.empty

--- a/test/uk/gov/hmrc/crsfatcafimanagement/connector/CADXConnectorSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/connector/CADXConnectorSpec.scala
@@ -56,7 +56,7 @@ class CADXConnectorSpec extends SpecBase with WireMockServerHandler with Generat
     "create FI" - {
       "must return status as OK for update Subscription" in {
         stubResponse(
-          "/ASMService/v1/FIManagement",
+          "/dac6/dct139a/v1",
           OK
         )
 
@@ -72,7 +72,7 @@ class CADXConnectorSpec extends SpecBase with WireMockServerHandler with Generat
         forAll(arbitrary[FIDetailsRequest[CreateRequestDetails]], errorCodes) {
           (sub, errorCode) =>
             stubResponse(
-              "/ASMService/v1/FIManagement",
+              "/dac6/dct139a/v1",
               errorCode
             )
 
@@ -84,7 +84,7 @@ class CADXConnectorSpec extends SpecBase with WireMockServerHandler with Generat
     "update FI" - {
       "must return status as OK for update Subscription" in {
         stubResponse(
-          "/ASMService/v1/FIManagement",
+          "/dac6/dct139a/v1",
           OK
         )
 
@@ -100,7 +100,7 @@ class CADXConnectorSpec extends SpecBase with WireMockServerHandler with Generat
         forAll(arbitrary[FIDetailsRequest[UpdateRequestDetails]], errorCodes) {
           (sub, errorCode) =>
             stubResponse(
-              "/ASMService/v1/FIManagement",
+              "/dac6/dct139a/v1",
               errorCode
             )
 
@@ -112,7 +112,7 @@ class CADXConnectorSpec extends SpecBase with WireMockServerHandler with Generat
     "remove FI" - {
       "must return status as OK for removal request" in {
         stubResponse(
-          "/ASMService/v1/FIManagement",
+          "/dac6/dct139a/v1",
           OK
         )
 
@@ -128,7 +128,7 @@ class CADXConnectorSpec extends SpecBase with WireMockServerHandler with Generat
         forAll(arbitrary[RemoveFIDetailsRequest], errorCodes) {
           (req, errorCode) =>
             stubResponse(
-              "/ASMService/v1/FIManagement",
+              "/dac6/dct139a/v1",
               errorCode
             )
 


### PR DESCRIPTION
Revised API context paths from "/ASMService/v1" to updated endpoints "/dac6/dct139a/v1" and "/dac6/dct139b/v1" in test specs and configuration. This ensures alignment with the latest service endpoint changes.