### PR TITLE
DAC6-3459: Return submission response

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementController.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementController.scala
@@ -70,7 +70,7 @@ class FIManagementController @Inject() (
             },
           validReq =>
             service.createOrUpdateFI(validReq).map {
-              case Right(_) => Ok
+              case Right(response) => Ok(response)
               case Left(CreateSubmissionError(value)) =>
                 logger.warn(s"CreateSubmissionError $value")
                 InternalServerError(s"CreateSubmissionError $value")

--- a/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
@@ -16,9 +16,11 @@
 
 package uk.gov.hmrc.crsfatcafimanagement.services
 
+import org.apache.pekko.http.scaladsl.model.HttpResponse
 import play.api.Logging
 import play.api.http.Status.OK
 import play.api.libs.json.Writes
+import play.api.mvc.Result
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
 import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels._
 import uk.gov.hmrc.crsfatcafimanagement.models.RequestType
@@ -37,7 +39,7 @@ class CADXSubmissionService @Inject() (connector: CADXConnector) extends Logging
     hc: HeaderCarrier,
     ex: ExecutionContext,
     writes: Writes[FIManagement[FIDetailsRequest[T]]]
-  ): Future[Either[CreateSubmissionError, Unit]] = {
+  ): Future[Either[CreateSubmissionError, String]] = {
     val requestType = requestDetails match {
       case _: CreateRequestDetails => RequestType.CREATE
       case _: UpdateRequestDetails => RequestType.UPDATE
@@ -53,7 +55,7 @@ class CADXSubmissionService @Inject() (connector: CADXConnector) extends Logging
     connector.createFI(request).map {
       res =>
         res.status match {
-          case OK => Right(())
+          case OK => Right(res.body)
           case status =>
             logger.warn(s"create submission Got Status $status")
             Left(CreateSubmissionError(status))

--- a/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionService.scala
@@ -16,11 +16,9 @@
 
 package uk.gov.hmrc.crsfatcafimanagement.services
 
-import org.apache.pekko.http.scaladsl.model.HttpResponse
 import play.api.Logging
 import play.api.http.Status.OK
 import play.api.libs.json.Writes
-import play.api.mvc.Result
 import uk.gov.hmrc.crsfatcafimanagement.connectors.CADXConnector
 import uk.gov.hmrc.crsfatcafimanagement.models.CADXRequestModels._
 import uk.gov.hmrc.crsfatcafimanagement.models.RequestType

--- a/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
@@ -241,7 +241,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
             )
         ).thenReturn(
           Future.successful(
-            Right(())
+            Right("testFIID")
           )
         )
 
@@ -266,7 +266,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
             )
         ).thenReturn(
           Future.successful(
-            Right(())
+            Right("testFIID")
           )
         )
 
@@ -318,7 +318,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
             )
         ).thenReturn(
           Future.successful(
-            Right(())
+            Right("testFIID")
           )
         )
 
@@ -343,7 +343,7 @@ class FIManagementControllerSpec extends SpecBase with Generators {
             )
         ).thenReturn(
           Future.successful(
-            Right(())
+            Right("testFIID")
           )
         )
 

--- a/test/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionServiceSpec.scala
@@ -104,7 +104,7 @@ class CADXSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach {
                                                       any[Writes[FIManagement[FIDetailsRequest[CreateRequestDetails]]]]()
           )
         )
-          .thenReturn(Future.successful(HttpResponse(OK, "Good Response")))
+          .thenReturn(Future.successful(HttpResponse(OK, "testFIID")))
 
         val result = service.createOrUpdateFI(createRequestDetails)
 
@@ -114,7 +114,7 @@ class CADXSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach {
                                                                           any[ExecutionContext](),
                                                                           any[Writes[FIManagement[FIDetailsRequest[CreateRequestDetails]]]]
             )
-            sub mustBe Right(())
+            sub mustBe Right("testFIID")
         }
       }
 
@@ -166,7 +166,7 @@ class CADXSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach {
                                                       any[Writes[FIManagement[FIDetailsRequest[UpdateRequestDetails]]]]
           )
         )
-          .thenReturn(Future.successful(HttpResponse(OK, "Good Response")))
+          .thenReturn(Future.successful(HttpResponse(OK, "testFIID")))
 
         val result = service.createOrUpdateFI(updateRequestDetails)
 
@@ -176,7 +176,7 @@ class CADXSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach {
                                                                           any[ExecutionContext](),
                                                                           any[Writes[FIManagement[FIDetailsRequest[UpdateRequestDetails]]]]
             )
-            sub mustBe Right(())
+            sub mustBe Right("testFIID")
         }
       }
     }


### PR DESCRIPTION
Updated the service to return the response body upon successful FI submission instead of a unit. Adjusted the controller to include the response in the HTTP OK result.