### PR TITLE
DAC6-3602: Remove `IsFATCAReporting` field

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/CADXRequestModels/RequestDetails.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/CADXRequestModels/RequestDetails.scala
@@ -23,7 +23,6 @@ sealed trait RequestDetails {
   val SubscriptionID: String
   val TINDetails: List[TINDetails]
   val IsFIUser: Boolean
-  val IsFATCAReporting: Boolean
   val AddressDetails: AddressDetails
   val PrimaryContactDetails: Option[ContactDetails]   = None
   val SecondaryContactDetails: Option[ContactDetails] = None
@@ -38,7 +37,6 @@ final case class CreateRequestDetails(
   SubscriptionID: String,
   TINDetails: List[TINDetails],
   IsFIUser: Boolean,
-  IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
   override val PrimaryContactDetails: Option[ContactDetails] = None,
   override val SecondaryContactDetails: Option[ContactDetails] = None
@@ -54,7 +52,6 @@ final case class UpdateRequestDetails(
   SubscriptionID: String,
   TINDetails: List[TINDetails],
   IsFIUser: Boolean,
-  IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
   override val PrimaryContactDetails: Option[ContactDetails] = None,
   override val SecondaryContactDetails: Option[ContactDetails] = None
@@ -70,7 +67,6 @@ final case class RemoveRequestDetails(
   FIName: Option[String] = None,
   TINDetails: Option[List[TINDetails]] = None,
   IsFIUser: Option[Boolean] = None,
-  IsFATCAReporting: Option[Boolean] = None,
   PrimaryContactDetails: Option[ContactDetails] = None,
   SecondaryContactDetails: Option[ContactDetails] = None,
   AddressDetails: Option[AddressDetails] = None

--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/FIDetail.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/FIDetail.scala
@@ -24,7 +24,6 @@ final case class FIDetail(
   SubscriptionID: String,
   TINDetails: TINDetails,
   IsFIUser: Boolean,
-  IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
   PrimaryContactDetails: ContactDetails,
   SecondaryContactDetails: ContactDetails

--- a/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
+++ b/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
@@ -70,7 +70,6 @@ trait ModelGenerators {
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
       isFIUser                <- arbitrary[Boolean]
-      isFATCAReporting        <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
       secondaryContactDetails <- arbitrary[ContactDetails]
@@ -80,7 +79,6 @@ trait ModelGenerators {
       SubscriptionID = subscriptionId,
       TINDetails = tinDetails,
       IsFIUser = isFIUser,
-      IsFATCAReporting = isFATCAReporting,
       AddressDetails = addressDetails,
       PrimaryContactDetails = primaryContactDetails,
       SecondaryContactDetails = secondaryContactDetails
@@ -178,7 +176,6 @@ trait ModelGenerators {
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
       isFIUser                <- arbitrary[Boolean]
-      isFATCAReporting        <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
       secondaryContactDetails <- arbitrary[ContactDetails]
@@ -187,7 +184,6 @@ trait ModelGenerators {
       SubscriptionID = subscriptionId,
       TINDetails = List(tinDetails),
       IsFIUser = isFIUser,
-      IsFATCAReporting = isFATCAReporting,
       AddressDetails = addressDetails,
       PrimaryContactDetails = Some(primaryContactDetails),
       SecondaryContactDetails = Some(secondaryContactDetails)
@@ -201,7 +197,6 @@ trait ModelGenerators {
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
       isFIUser                <- arbitrary[Boolean]
-      isFATCAReporting        <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
       secondaryContactDetails <- arbitrary[ContactDetails]
@@ -211,7 +206,6 @@ trait ModelGenerators {
       SubscriptionID = subscriptionId,
       TINDetails = List(tinDetails),
       IsFIUser = isFIUser,
-      IsFATCAReporting = isFATCAReporting,
       AddressDetails = addressDetails,
       PrimaryContactDetails = Some(primaryContactDetails),
       SecondaryContactDetails = Some(secondaryContactDetails)

--- a/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
@@ -84,7 +84,6 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       |    }
       |  ],
       |  "IsFIUser": false,
-      |  "IsFATCAReporting": true,
       |  "PrimaryContactDetails": {
       |    "PhoneNumber": "07123456789",
       |    "ContactName": "John Doe",

--- a/test/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionServiceSpec.scala
@@ -51,7 +51,6 @@ class CADXSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach {
       |    }
       |  ],
       |  "IsFIUser": false,
-      |  "IsFATCAReporting": true,
       |  "PrimaryContactDetails": {
       |    "PhoneNumber": "07123456789",
       |    "ContactName": "John Doe",


### PR DESCRIPTION
Eliminated the unused `IsFATCAReporting` field from models, generators, and tests to simplify data structures. This change reduces redundancy and ensures better alignment with current system requirements.