### PR TITLE
DAC6-3620: Remove UTF-8 parameter in headers

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/connectors/CADXConnector.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/connectors/CADXConnector.scala
@@ -44,7 +44,7 @@ class CADXConnector @Inject() (
 
     http
       .post(url"${config.baseUrl(serviceName)}")
-      .setHeader(extraHeaders(config, serviceName, utf8 = true): _*)
+      .setHeader(extraHeaders(config, serviceName): _*)
       .withBody(Json.toJson(submissionDetails))
       .execute[HttpResponse]
   }
@@ -54,7 +54,7 @@ class CADXConnector @Inject() (
 
     http
       .post(url"${config.baseUrl(serviceName)}")
-      .setHeader(extraHeaders(config, serviceName, utf8 = true): _*)
+      .setHeader(extraHeaders(config, serviceName): _*)
       .withBody(Json.toJson(removeDetails))
       .execute[HttpResponse]
   }
@@ -75,23 +75,18 @@ class CADXConnector @Inject() (
 
   private[connectors] def extraHeaders(
     config: AppConfig,
-    serviceName: String,
-    utf8: Boolean = false
+    serviceName: String
   )(implicit headerCarrier: HeaderCarrier): Seq[(String, String)] = {
     val newHeaders = headerCarrier
       .copy(authorization = Some(Authorization(s"Bearer ${config.bearerToken(serviceName)}")))
 
-    newHeaders.headers(Seq(HeaderNames.authorisation)) ++ addHeaders(
-      config.environment(serviceName),
-      utf8
-    )
+    newHeaders.headers(Seq(HeaderNames.authorisation)) ++ addHeaders(config.environment(serviceName))
   }
 
-  private[connectors] def addHeaders(eisEnvironment: String, utf8: Boolean)(implicit headerCarrier: HeaderCarrier): Seq[(String, String)] = {
+  private[connectors] def addHeaders(eisEnvironment: String)(implicit headerCarrier: HeaderCarrier): Seq[(String, String)] = {
     // HTTP-date format defined by RFC 7231 e.g. Fri, 01 Aug 2020 15:51:38 UTC
     val formatter                      = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'UTC'").withZone(ZoneId.of("UTC"))
     val stripSession: String => String = (input: String) => input.replace("session-", "")
-    val contentType                    = if (utf8) "application/json;charset=UTF-8" else "application/json"
 
     Seq(
       "x-forwarded-host" -> "mdtp",
@@ -103,7 +98,7 @@ class CADXConnector @Inject() (
         )
         .getOrElse(UUID.randomUUID().toString),
       "x-regime-type" -> "CRSFATCA",
-      "content-type"  -> contentType,
+      "content-type"  -> "application/json",
       "accept"        -> "application/json",
       "Environment"   -> eisEnvironment
     )

--- a/it/test/uk/gov/hmrc/crsfatcafimanagement/connectors/CADXConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/crsfatcafimanagement/connectors/CADXConnectorSpec.scala
@@ -58,13 +58,6 @@ class CADXConnectorSpec extends SpecBase with Generators with IntegrationPatienc
     "content-type"     -> "application/json"
   )
 
-  private val requiredUtf8Headers = Map(
-    "x-forwarded-host" -> "mdtp",
-    "x-regime-type"    -> "CRSFATCA",
-    "accept"           -> "application/json",
-    "content-type"     -> "application/json;charset=UTF-8"
-  )
-
   private val errorStatusCodes = Table(
     "errorStatus",
     FORBIDDEN,
@@ -174,7 +167,7 @@ class CADXConnectorSpec extends SpecBase with Generators with IntegrationPatienc
               url = "/dac6/dct139a/v1",
               statusCode = OK,
               requestMethod = RequestMethod.POST,
-              requestHeaders = requiredUtf8Headers,
+              requestHeaders = requiredHeaders,
               responseBody = Json.prettyPrint(Json.toJson(fiDetail))
             )
 

--- a/test/uk/gov/hmrc/crsfatcafimanagement/models/RequestDetailsSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/models/RequestDetailsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.crsfatcafimanagement.models
 
 import play.api.libs.json.Json


### PR DESCRIPTION
Removed the unnecessary `utf8` parameter from headers configuration in `CADXConnector`. Adjusted tests accordingly and simplified the logic by using a single `application/json` content type.