### PR TITLE
DAC6-3609: Remove GIIN from TINType

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/FIDetail.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/FIDetail.scala
@@ -23,6 +23,7 @@ final case class FIDetail(
   FIName: String,
   SubscriptionID: String,
   TINDetails: TINDetails,
+  GIIN: Option[String],
   IsFIUser: Boolean,
   AddressDetails: AddressDetails,
   PrimaryContactDetails: ContactDetails,

--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/TINType.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/TINType.scala
@@ -23,11 +23,10 @@ sealed trait TINType
 object TINType {
 
   case object UTR extends TINType
-  case object GIIN extends TINType
   case object CRN extends TINType
   case object TRN extends TINType
 
-  val allValues: Seq[TINType] = Seq(UTR, CRN, TRN, GIIN)
+  val allValues: Seq[TINType] = Seq(UTR, CRN, TRN)
 
   private val stringMapping: Map[String, TINType] = allValues
     .map(

--- a/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
+++ b/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
@@ -69,6 +69,7 @@ trait ModelGenerators {
       fiName                  <- stringOfLength(105)
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
+      giin                    <- Gen.option(stringOfLength(8))
       isFIUser                <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
@@ -78,6 +79,7 @@ trait ModelGenerators {
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = tinDetails,
+      GIIN = giin,
       IsFIUser = isFIUser,
       AddressDetails = addressDetails,
       PrimaryContactDetails = primaryContactDetails,

--- a/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/controllers/FIManagementControllerSpec.scala
@@ -76,13 +76,8 @@ class FIManagementControllerSpec extends SpecBase with Generators {
       |  "SubscriptionID": "123456789012345",
       |  "FIID": "FI1234567890123",
       |  "FIName": "Financial Institution",
-      |  "TINDetails": [
-      |    {
-      |      "TIN": "TIN123456789",
-      |      "TINType": "GIIN",
-      |      "IssuedBy": "US"
-      |    }
-      |  ],
+      |  "TINDetails": [],
+      |  "GIIN": "TIN123456789",
       |  "IsFIUser": false,
       |  "PrimaryContactDetails": {
       |    "PhoneNumber": "07123456789",

--- a/test/uk/gov/hmrc/crsfatcafimanagement/models/RequestDetailsSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/models/RequestDetailsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.crsfatcafimanagement.models
 
 import play.api.libs.json.Json

--- a/test/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/services/CADXSubmissionServiceSpec.scala
@@ -43,13 +43,8 @@ class CADXSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach {
       |  "SubscriptionID": "123456789012345",
       |  "FIID": "FI1234567890123",
       |  "FIName": "Financial Institution",
-      |  "TINDetails": [
-      |    {
-      |      "TIN": "TIN123456789",
-      |      "TINType": "GIIN",
-      |      "IssuedBy": "US"
-      |    }
-      |  ],
+      |  "TINDetails": [],
+      |  "GIIN": "TIN123456789",
       |  "IsFIUser": false,
       |  "PrimaryContactDetails": {
       |    "PhoneNumber": "07123456789",


### PR DESCRIPTION
Replaced the GIIN `TINType` with a new optional `GIIN` field in `FIDetail`. Updated related models, generators, and tests to reflect this structural change, simplifying TIN handling.