### PR TITLE
DAC6-3609: Add GIIN field

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/CADXRequestModels/RequestDetails.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/CADXRequestModels/RequestDetails.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.crsfatcafimanagement.models.{AddressDetails, ContactDetails, 
 sealed trait RequestDetails {
   val SubscriptionID: String
   val TINDetails: List[TINDetails]
+  val GIIN: Option[String]
   val IsFIUser: Boolean
   val AddressDetails: AddressDetails
   val PrimaryContactDetails: Option[ContactDetails]   = None
@@ -41,6 +42,7 @@ final case class CreateRequestDetails(
   FIName: String,
   SubscriptionID: String,
   TINDetails: List[TINDetails],
+  GIIN: Option[String],
   IsFIUser: Boolean,
   AddressDetails: AddressDetails,
   override val PrimaryContactDetails: Option[ContactDetails] = None,
@@ -57,6 +59,7 @@ final case class UpdateRequestDetails(
   FIName: String,
   SubscriptionID: String,
   TINDetails: List[TINDetails],
+  GIIN: Option[String],
   IsFIUser: Boolean,
   AddressDetails: AddressDetails,
   override val PrimaryContactDetails: Option[ContactDetails] = None,
@@ -73,6 +76,7 @@ final case class RemoveRequestDetails(
   FIID: String,
   FIName: Option[String] = None,
   TINDetails: Option[List[TINDetails]] = None,
+  GIIN: Option[String] = None,
   IsFIUser: Option[Boolean] = None,
   PrimaryContactDetails: Option[ContactDetails] = None,
   SecondaryContactDetails: Option[ContactDetails] = None,

--- a/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
+++ b/test-common/uk/gov/hmrc/crsfatcafimanagement/generators/ModelGenerators.scala
@@ -177,6 +177,7 @@ trait ModelGenerators {
       fiName                  <- stringOfLength(105)
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
+      giin                    <- Gen.option(stringOfLength(8))
       isFIUser                <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
@@ -185,6 +186,7 @@ trait ModelGenerators {
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = List(tinDetails),
+      GIIN = giin,
       IsFIUser = isFIUser,
       AddressDetails = addressDetails,
       PrimaryContactDetails = Some(primaryContactDetails),
@@ -198,6 +200,7 @@ trait ModelGenerators {
       fiName                  <- stringOfLength(105)
       subscriptionId          <- validSubscriptionID
       tinDetails              <- arbitrary[TINDetails]
+      giin                    <- Gen.option(stringOfLength(8))
       isFIUser                <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
@@ -207,6 +210,7 @@ trait ModelGenerators {
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = List(tinDetails),
+      GIIN = giin,
       IsFIUser = isFIUser,
       AddressDetails = addressDetails,
       PrimaryContactDetails = Some(primaryContactDetails),

--- a/test/uk/gov/hmrc/crsfatcafimanagement/models/RequestDetailsSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcafimanagement/models/RequestDetailsSpec.scala
@@ -29,6 +29,7 @@ class RequestDetailsSpec extends SpecBase {
         "FIName",
         "SubscriptionID",
         List.empty,
+        Some("GIIN"),
         IsFIUser = true,
         AddressDetails(
           "AddressLine1",
@@ -54,6 +55,7 @@ class RequestDetailsSpec extends SpecBase {
           |  "SubscriptionID" : "SubscriptionID",
           |  "TINDetails" : [ ],
           |  "IsFIUser" : true,
+          |  "GIIN" : "GIIN",
           |  "AddressDetails" : {
           |    "AddressLine1" : "AddressLine1",
           |    "AddressLine3" : "AddressLine3",
@@ -78,6 +80,7 @@ class RequestDetailsSpec extends SpecBase {
         "FIName",
         "SubscriptionID",
         List.empty,
+        Some("GIIN"),
         IsFIUser = true,
         AddressDetails(
           "AddressLine1",
@@ -103,6 +106,7 @@ class RequestDetailsSpec extends SpecBase {
           |  "FIName": "FIName",
           |  "SubscriptionID": "SubscriptionID",
           |  "TINDetails": [],
+          |  "GIIN": "GIIN",
           |  "IsFIUser": true,
           |  "AddressDetails": {
           |    "AddressLine1": "AddressLine1",


### PR DESCRIPTION
Introduced an optional `GIIN` field to `RequestDetails` and related models for enhanced data representation. Updated generators and test cases to ensure compatibility with this new field.