### PR TITLE
DAC6-3633: Rename TRN to TURN in TINType

### DIFF
--- a/app/uk/gov/hmrc/crsfatcafimanagement/models/TINType.scala
+++ b/app/uk/gov/hmrc/crsfatcafimanagement/models/TINType.scala
@@ -24,9 +24,9 @@ object TINType {
 
   case object UTR extends TINType
   case object CRN extends TINType
-  case object TRN extends TINType
+  case object TURN extends TINType
 
-  val allValues: Seq[TINType] = Seq(UTR, CRN, TRN)
+  val allValues: Seq[TINType] = Seq(UTR, CRN, TURN)
 
   private val stringMapping: Map[String, TINType] = allValues
     .map(


### PR DESCRIPTION
Updated the TINType enumeration by renaming the TRN case object to TURN. Adjusted the allValues sequence to reflect the change, ensuring consistency across the model.